### PR TITLE
start correctly when a loopval is not set in config

### DIFF
--- a/bmp_play.py
+++ b/bmp_play.py
@@ -92,9 +92,9 @@ def play(cfg):
         sock.connect((cfg['dest_addr'], cfg['port']))
         print("Connected, sending data...")
 
-        if int(cfg['loop']) != 0:
-            print("Looping %s times over input file" % int(cfg['loop']))
-            for val in range(0, int(cfg['loop'])):
+        if loopval != 0:
+            print("Looping %s times over input file" % loopval)
+            for val in range(0, loopval):
                 sys.stdout.write('.')
                 sys.stdout.flush()
                 with open(cfg['file'], "rb") as f:


### PR DESCRIPTION
When you don't set a loop value on the command line, the current software fails with this exception:

```
root@x:~# bmp_play.py -m play -p 1790 -f bmp.dump -d 127.0.0.1
Sending contents of 'bmp.dump' to 127.0.0.1
Connected, sending data...
Traceback (most recent call last):
  File "/usr/sbin/bmp_play.py", line 275, in <module>
    main()
  File "/usr/sbin/bmp_play.py", line 271, in main
    play(cfg)
  File "/usr/sbin/bmp_play.py", line 95, in play
    if int(cfg['loop']) != 0:
TypeError: int() argument must be a string or a number, not 'NoneType'
```

I can see elsewhere in the script there is an attempt to handle this but the fix doesn't make it as far as this bit of the file.